### PR TITLE
Updates for Apt::Source to manage key, IPv6 address binding.

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -30,7 +30,7 @@ clickhouse::interserver_http_port: 9009
 clickhouse::interserver_http_host: ~
 clickhouse::listen_hosts:
   - '127.0.0.1'
-  - '::'
+  - '::1'
 clickhouse::mark_cache_size: 5368709120
 clickhouse::max_connections: 4096
 clickhouse::keep_alive_timeout: 3

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,6 +87,19 @@ class clickhouse (
   Integer[0]                                  $default_execution_time,
   Optional[Hash[String[1], Clickhouse::User]] $users,
 ) {
+  apt::source { 'clickhouse':
+    location => 'http://repo.yandex.ru/clickhouse/deb/stable',
+    release  => 'main/',
+    repos    => '',
+    key      => {
+      id     => '9EBB357BC2B0876A774500C7C8F1E19FE0C56BD4',
+      server => 'hkp://keyserver.ubuntu.com:80',
+    },
+    include  => {
+      src => false,
+      deb => true,
+    },
+  }
   ensure_packages([$package])
   if $dictionaries_config_source {
     file {$conf_dir:

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "icann-clickhouse",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "john.bond@icann.org",
   "summary": "Module to install and manage clickhouse",
   "license": "Apache-2.0",
@@ -10,13 +10,18 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.25.1 <5.0.0"
+    },
+    {
+      "name": "puppetlabs-apt",
+      "version_requirement": ">= 6.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "16.04",
+        "18.04",
       ]
     }
   ],


### PR DESCRIPTION
- Fixes issue where '::' is specified instead of ::1 for v6 localhost service binding.
- Adding support for managing Apt key and source for Yanex repo.
- Metadata updates to make puppetlabs-apt a dependency.