### PR TITLE
Implemented optional ZooKeeper configuration

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -90,3 +90,5 @@ clickhouse::default_result_rows: 0
 clickhouse::default_read_rows: 0
 clickhouse::default_execution_time: 0
 clickhouse::users: {}
+clickhouse::zookeeper_servers: []
+clickhouse::zookeeper_port: 2181

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,8 @@ class clickhouse (
   Integer[0]                                  $default_read_rows,
   Integer[0]                                  $default_execution_time,
   Optional[Hash[String[1], Clickhouse::User]] $users,
+  Optional[Array[Stdlib::IP::Address]]        $zookeeper_servers,
+  Optional[Integer[0]]                        $zookeeper_port,
 ) {
   ensure_packages([$package])
   if $dictionaries_config_source {

--- a/templates/etc/config.xml.erb
+++ b/templates/etc/config.xml.erb
@@ -106,7 +106,16 @@
     </<%= remote %>>
 <%- end -%>
   </remote_servers>
-  <zookeeper incl="zookeeper-servers" optional="true" />
+    <zookeeper>
+     <%- if @zookeeper_servers -%>
+        <%- @zookeeper_servers.each do |server_addr, index| -%>
+            <node index="<%= index %>">
+                <host><%= server_addr %></host>
+                <port><%= @zookeeper_port %></port>
+            </node>
+        <%- end -%>
+     <%- end -%>
+  </zookeeper>
   <macros incl="macros" optional="true" />
   <builtin_dictionaries_reload_interval><%= @builtin_dictionaries_reload_interval %></builtin_dictionaries_reload_interval>
   <max_session_timeout><%= @max_session_timeout %></max_session_timeout>

--- a/templates/etc/config.xml.erb
+++ b/templates/etc/config.xml.erb
@@ -108,8 +108,8 @@
   </remote_servers>
     <zookeeper>
      <%- if @zookeeper_servers -%>
-        <%- @zookeeper_servers.each do |server_addr, index| -%>
-            <node index="<%= index %>">
+        <%- @zookeeper_servers.each do |server_addr| -%>
+            <node>
                 <host><%= server_addr %></host>
                 <port><%= @zookeeper_port %></port>
             </node>

--- a/templates/etc/config.xml.erb
+++ b/templates/etc/config.xml.erb
@@ -106,7 +106,16 @@
     </<%= remote %>>
 <%- end -%>
   </remote_servers>
-  <zookeeper incl="zookeeper-servers" optional="true" />
+    <zookeeper>
+     <%- if @zookeeper_servers -%>
+        <%- @zookeeper_servers.each do |server_addr| -%>
+            <node>
+                <host><%= server_addr %></host>
+                <port><%= @zookeeper_port %></port>
+            </node>
+        <%- end -%>
+     <%- end -%>
+  </zookeeper>
   <macros incl="macros" optional="true" />
   <builtin_dictionaries_reload_interval><%= @builtin_dictionaries_reload_interval %></builtin_dictionaries_reload_interval>
   <max_session_timeout><%= @max_session_timeout %></max_session_timeout>


### PR DESCRIPTION
We require the ability to configure Clickhouse to use a ZooKeeper cluster I have implemented the changes following the configuration guidance provided here: https://clickhouse.yandex/docs/en/operations/table_engines/replication/

All of this configuration is optional and has no impact if it's not provided